### PR TITLE
Test Dependency Ordering

### DIFF
--- a/Xunit.Extensions.Ordering.Tests/DependencyOrderedTests.cs
+++ b/Xunit.Extensions.Ordering.Tests/DependencyOrderedTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace Xunit.Extensions.Ordering.Tests
+{
+    [Trait("Ordered", "Dependency")]
+    [TestCaseOrderer(TestDependencyOrderer.TypeName, TestDependencyOrderer.AssemblyName)]
+    public partial class DependencyOrderTests 
+    {
+        public static List<int> ExecutionOrder { get; set; } = new List<int>();
+
+        [Fact]
+        [TestDependency("DependencyOrderedTest1")]
+        public void DependencyOrderedTest0()
+        {
+            ExecutionOrder.Add(0);
+            Assert.Contains(1, ExecutionOrder);
+            Assert.Contains(2, ExecutionOrder);
+            Assert.Contains(3, ExecutionOrder);
+        }
+
+        [Fact]
+        [TestDependency("DependencyOrderedTest3")]
+        public void DependencyOrderedTest2()
+        {
+            ExecutionOrder.Add(2);
+            Assert.DoesNotContain(0, ExecutionOrder);
+            Assert.DoesNotContain(1, ExecutionOrder);
+            Assert.Contains(3, ExecutionOrder);
+        }
+    }
+
+    public partial class DependencyOrderTests
+    {
+        [Fact]        
+        public void DependencyOrderedTest3()
+        {
+            ExecutionOrder.Add(3);
+            Assert.DoesNotContain(0, ExecutionOrder);
+            Assert.DoesNotContain(1, ExecutionOrder);
+            Assert.DoesNotContain(2, ExecutionOrder);
+        }
+
+        [Fact]
+        [TestDependency("DependencyOrderedTest2")]
+        public void DependencyOrderedTest1()
+        {
+            ExecutionOrder.Add(1);
+            Assert.DoesNotContain(0, ExecutionOrder);
+            Assert.Contains(2, ExecutionOrder);
+            Assert.Contains(3, ExecutionOrder);
+        }
+    }
+}

--- a/Xunit.Extensions.Ordering.Tests/TopologicalSortTests.cs
+++ b/Xunit.Extensions.Ordering.Tests/TopologicalSortTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+
+namespace Xunit.Extensions.Ordering.Tests
+{ 
+
+    public class Sort
+    {
+        [Fact]
+        [Trait("Order", "TopologicalSort")]
+        // ReSharper disable once InconsistentNaming
+        public void TopologicalSortTest()
+        {
+            var t = typeof(Xunit.Extensions.Ordering.TestDependencyOrderer);
+            var a = new Item("A");
+            var b = new Item("B", "C", "E");
+            var c = new Item("C");
+            var d = new Item("D", "A");
+            var e = new Item("E", "D", "G");
+            var f = new Item("F");
+            var g = new Item("G", "F", "H");
+            var h = new Item("H");
+
+            var unsorted = new[] { a, b, c, d, e, f, g, h };
+            var expected = new[] { a, c, d, f, h, g, e, b };
+            var sorted = unsorted.TSort(x => x.Dependencies, y => y.DisplayName);
+            Assert.Equal(expected, sorted);
+        }
+    }
+
+    public class Item
+    {
+        public IEnumerable<string> Dependencies { get; private set; }
+        public string DisplayName { get; }
+        public Item(string name, params string[] dependencies)
+        {
+            DisplayName = name;
+            Dependencies = dependencies;
+        }
+    }
+}

--- a/Xunit.Extensions.Ordering.Tests/xunit.runner.json
+++ b/Xunit.Extensions.Ordering.Tests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://xunit.github.io/schema/current/xunit.runner.schema.json",
-	"diagnosticMessages": true
+  "diagnosticMessages": true,
+  "methodDisplay": "method"
 }

--- a/Xunit.Extensions.Ordering.sln
+++ b/Xunit.Extensions.Ordering.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.329
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xunit.Extensions.Ordering", "Xunit.Extensions.Ordering\Xunit.Extensions.Ordering.csproj", "{BBEF35AA-4C38-4F21-99C6-DB4FEE7F3049}"
 EndProject

--- a/Xunit.Extensions.Ordering/TestDependencyAttribute.cs
+++ b/Xunit.Extensions.Ordering/TestDependencyAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xunit.Extensions.Ordering
+{
+    /// <summary>
+    /// Attribute used to indicate the name(s) of proceeding tests which are depended on. 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class TestDependencyAttribute : Attribute
+    {
+        /// <summary>        
+        /// </summary>
+        /// <param name="tests">Test Method names this method depend on having run first</param>
+        public TestDependencyAttribute(params string[] tests) => Tests = tests.ToList();
+
+        /// <summary>
+        /// Test Method names this method depend on having run first
+        /// </summary>
+        public IReadOnlyList<string> Tests { get; }
+    }
+}

--- a/Xunit.Extensions.Ordering/TestDependencyOrderer.cs
+++ b/Xunit.Extensions.Ordering/TestDependencyOrderer.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.Extensions.Ordering
+{
+    /// <summary>
+    /// Custom test case orderer which builds order based on TestDependencyAttribute data
+    /// </summary>
+    public class TestDependencyOrderer : ITestCaseOrderer, ITestCollectionOrderer
+    {
+        public const string TypeName = "Xunit.Extensions.Ordering.TestDependencyOrderer";
+
+        public const string AssemblyName = "Xunit.Extensions.Ordering";
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+            where TTestCase : ITestCase
+        {
+            var enumerable = testCases.ToList();
+            if (enumerable.Count() > 1)
+            {
+                var y = enumerable.TSort(
+                    x => x.TestMethod.Method
+                        .GetCustomAttributes((typeof(TestDependencyAttribute).AssemblyQualifiedName)).FirstOrDefault()
+                        ?.GetNamedArgument<IReadOnlyList<string>>("Tests"), x => x.DisplayName);
+                return y;
+            }
+
+            return enumerable;
+        }
+
+        public IEnumerable<ITestCollection> OrderTestCollections(IEnumerable<ITestCollection> testCollections)
+        {
+            var y = testCollections.TSort(
+                x => x.CollectionDefinition.GetCustomAttributes((typeof(TestDependencyAttribute).AssemblyQualifiedName))
+                    .FirstOrDefault()?.GetNamedArgument<IReadOnlyList<string>>("Tests"), x => x.DisplayName);
+            return y;
+        }
+    }
+}

--- a/Xunit.Extensions.Ordering/TestTopologicalSort.cs
+++ b/Xunit.Extensions.Ordering/TestTopologicalSort.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xunit.Extensions.Ordering
+{
+    /// <summary>
+    /// Classes used to build a Topological Sort of tests based on their dependencies
+    /// </summary>
+    /// Adapted from https://www.codeproject.com/Articles/869059/Topological-sorting-in-Csharp
+    public static class TestTopologicalSort
+    {
+        private static Func<T, IEnumerable<T>> RemapDependencies<T, TKey>(IEnumerable<T> source, Func<T, IEnumerable<TKey>> getDependencies, Func<T, TKey> getKey)
+        {
+            var map = source.ToDictionary(getKey);
+            return item =>
+            {
+                var dependencies = getDependencies(item);
+                return dependencies?.Select(key => map[key]);
+            };
+        }
+
+        public static IList<T> TSort<T, TKey>(this IEnumerable<T> source, Func<T, IEnumerable<TKey>> getDependencies, Func<T, TKey> getKey)
+        {
+            var enumerable = source as T[] ?? source.ToArray();
+            return TSort<T>(enumerable, RemapDependencies(enumerable, getDependencies, getKey));
+        }
+
+        public static IList<T> TSort<T>(this IEnumerable<T> source, Func<T, IEnumerable<T>> getDependencies)
+        {
+            var sorted = new List<T>();
+            var visited = new Dictionary<T, bool>();
+
+            foreach (var item in source)
+            {
+                Visit(item, getDependencies, sorted, visited);
+            }
+
+            return sorted;
+        }
+
+        public static void Visit<T>(T item, Func<T, IEnumerable<T>> getDependencies, List<T> sorted, Dictionary<T, bool> visited)
+        {
+            var alreadyVisited = visited.TryGetValue(item, out var inProcess);
+
+            if (alreadyVisited)
+            {
+                if (inProcess)
+                {
+                    throw new ArgumentException("Cyclic dependency found.");
+                }
+            }
+            else
+            {
+                visited[item] = true;
+
+                var dependencies = getDependencies(item);
+                if (dependencies != null)
+                {
+                    foreach (var dependency in dependencies)
+                    {
+                        Visit(dependency, getDependencies, sorted, visited);
+                    }
+                }
+
+                visited[item] = false;
+                sorted.Add(item);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
The TestDependency attribute is used to declare what the xUnit DisplayName of the previous test is. This means though that if you don't have the xunit,.runner.json set to use method name you must provide the fully qualified name. 

TestDependency takes an array of string so you can clearly define the dependency
D-->C
D-->B
C-->A
B-->A
So the run would be A,B,C,D or A,C,B,D.

The way I use this is to define sets within their own classes, that way the class runs as a collection in parallel against order classes while running ordered inside each class.

The test can be read via reflection and the data converted into mermaidjs markup or MSAGL graphics in order to visualize the dependencies (code not included in this request).